### PR TITLE
Revert "Axis - Don't start event stream without events configured"

### DIFF
--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -269,8 +269,7 @@ def setup_device(hass, config, device_config):
                                     config)
 
     AXIS_DEVICES[device.serial_number] = device
-    if event_types:
-        hass.add_job(device.start)
+    hass.add_job(device.start)
     return True
 
 


### PR DESCRIPTION
Reverts Kane610/home-assistant#1